### PR TITLE
Remove Calendar from WALL_CLOCK function

### DIFF
--- a/library/src/main/java/de/hannesstruss/unearthed/Unearthed.kt
+++ b/library/src/main/java/de/hannesstruss/unearthed/Unearthed.kt
@@ -5,14 +5,13 @@ import android.app.Application
 import android.os.Bundle
 import android.os.Process
 import androidx.annotation.MainThread
-import java.util.Calendar
 
 private const val KEY_TIME_OF_SAVE_EPOCH_MILLIS = "unearthed_time_of_save_epoch_millis"
 private const val KEY_PID_AT_SAVE = "unearthed_pid_at_save"
 private const val KEY_GRAVEYARD = "unearthed_graveyard"
 
 private val WALL_CLOCK = {
-  Calendar.getInstance().timeInMillis
+  System.currentTimeMillis()
 }
 
 class Unearthed internal constructor(


### PR DESCRIPTION
Removed in favor of System.currentTimeMillis() as it's more efficient than creating new instance of `GeorgianCalendar` via calling `Calendar.getInstance()` just to get epoch time in milliseconds.

See issue #5 to read the motivation behind this change.