### PR TITLE
Support activityName in Gravestone

### DIFF
--- a/library/src/androidTest/java/de/hannesstruss/unearthed/UnearthedTest.kt
+++ b/library/src/androidTest/java/de/hannesstruss/unearthed/UnearthedTest.kt
@@ -1,5 +1,6 @@
 package de.hannesstruss.unearthed
 
+import android.content.ComponentName
 import android.os.Bundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
@@ -8,12 +9,14 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class UnearthedTest {
+
   @Test
   fun singleDeath() {
     val state = Bundle()
+    val componentName = ComponentName("package", "class")
 
     val unearthed1 = Unearthed(1)
-    unearthed1.onActivitySaveInstanceState(state)
+    unearthed1.onActivitySaveInstanceState(state, componentName)
 
     val unearthed2 = Unearthed(2)
     var graveyardOpt: Graveyard? = null
@@ -28,12 +31,14 @@ class UnearthedTest {
   fun multipleDeaths() {
     val unearthed1 = Unearthed(1)
     val state1 = Bundle()
-    unearthed1.onActivitySaveInstanceState(state1)
+    val componentName1 = ComponentName("package1", "class1")
+    unearthed1.onActivitySaveInstanceState(state1, componentName1)
 
     val unearthed2 = Unearthed(2)
     unearthed2.onActivityCreated(state1)
     val state2 = Bundle()
-    unearthed2.onActivitySaveInstanceState(state2)
+    val componentName2 = ComponentName("package2", "class2")
+    unearthed2.onActivitySaveInstanceState(state2, componentName2)
 
     val unearthed3 = Unearthed(3)
     var graveyardOpt: Graveyard? = null
@@ -51,10 +56,12 @@ class UnearthedTest {
     val unearthed1 = Unearthed(1)
 
     val stateActivity1 = Bundle()
+    val componentName1 = ComponentName("package1", "class1")
     val stateActivity2 = Bundle()
+    val componentName2 = ComponentName("package2", "class2")
 
-    unearthed1.onActivitySaveInstanceState(stateActivity1)
-    unearthed1.onActivitySaveInstanceState(stateActivity2)
+    unearthed1.onActivitySaveInstanceState(stateActivity1, componentName1)
+    unearthed1.onActivitySaveInstanceState(stateActivity2, componentName2)
 
     val unearthed2 = Unearthed(2)
     var callbackCalls = 0
@@ -67,13 +74,14 @@ class UnearthedTest {
   }
 
   @Test
-  fun savesCorrectTime() {
+  fun savesCorrectTimeAndComponentName() {
     var now = 23L
     val clock = { now }
 
     val unearthed1 = Unearthed(1, epochClock = clock)
     val state1 = Bundle()
-    unearthed1.onActivitySaveInstanceState(state1)
+    val componentName1 = ComponentName("package1", "class1")
+    unearthed1.onActivitySaveInstanceState(state1, componentName1)
 
     now = 123L
 
@@ -85,13 +93,16 @@ class UnearthedTest {
     val graveyard = checkNotNull(graveyardOpt)
     assertThat(graveyard.gravestones.first().backgroundedEpochMillis).isEqualTo(23L)
     assertThat(graveyard.gravestones.first().millisToRestore).isEqualTo(123L - 23L)
+    assertThat(graveyard.gravestones.first().millisToRestore).isEqualTo(123L - 23L)
+    assertThat(graveyard.gravestones.first().componentName).isEqualTo(componentName1)
   }
 
   @Test
   fun callsCallbackAfterRestore() {
     val unearthed1 = Unearthed(1)
     val state1 = Bundle()
-    unearthed1.onActivitySaveInstanceState(state1)
+    val componentName1 = ComponentName("package1", "class1")
+    unearthed1.onActivitySaveInstanceState(state1, componentName1)
 
     val unearthed2 = Unearthed(2)
     unearthed2.onActivityCreated(state1)

--- a/library/src/main/java/de/hannesstruss/unearthed/Gravestone.kt
+++ b/library/src/main/java/de/hannesstruss/unearthed/Gravestone.kt
@@ -8,6 +8,9 @@ class Gravestone(
     /** ID of the process that died */
     val pid: Int,
 
+    /** Name of Activity which was visible when the process died */
+    val activityName: String,
+
     /** Time at which the activity was restored. Milliseconds since epoch. */
     val restoredAtEpochMillis: Long,
 

--- a/library/src/main/java/de/hannesstruss/unearthed/Gravestone.kt
+++ b/library/src/main/java/de/hannesstruss/unearthed/Gravestone.kt
@@ -1,5 +1,6 @@
 package de.hannesstruss.unearthed
 
+import android.content.ComponentName
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
@@ -8,8 +9,8 @@ class Gravestone(
     /** ID of the process that died */
     val pid: Int,
 
-    /** Name of Activity which was visible when the process died */
-    val activityName: String,
+    /** Name of component which was visible when the process died */
+    val componentName: ComponentName?,
 
     /** Time at which the activity was restored. Milliseconds since epoch. */
     val restoredAtEpochMillis: Long,

--- a/library/src/main/java/de/hannesstruss/unearthed/Unearthed.kt
+++ b/library/src/main/java/de/hannesstruss/unearthed/Unearthed.kt
@@ -2,13 +2,14 @@ package de.hannesstruss.unearthed
 
 import android.app.Activity
 import android.app.Application
+import android.content.ComponentName
 import android.os.Bundle
 import android.os.Process
 import androidx.annotation.MainThread
 
 private const val KEY_TIME_OF_SAVE_EPOCH_MILLIS = "unearthed_time_of_save_epoch_millis"
 private const val KEY_PID_AT_SAVE = "unearthed_pid_at_save"
-private const val KEY_ACTIVITY_NAME = "activity_name"
+private const val KEY_COMPONENT_NAME = "component_name"
 private const val KEY_GRAVEYARD = "unearthed_graveyard"
 
 private val WALL_CLOCK = {
@@ -30,7 +31,7 @@ class Unearthed internal constructor(
       app.registerActivityLifecycleCallbacks(object : EmptyActivityLifecycleCallbacks() {
         override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
           val unearthed = checkNotNull(instance)
-          unearthed.onActivitySaveInstanceState(outState, activity.javaClass.simpleName)
+          unearthed.onActivitySaveInstanceState(outState, activity.componentName)
         }
 
         override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
@@ -55,10 +56,10 @@ class Unearthed internal constructor(
   private val listeners = mutableSetOf<(Graveyard) -> Unit>()
   private var graveyard: Graveyard? = null
 
-  internal fun onActivitySaveInstanceState(outState: Bundle, activityName: String = "") {
+  internal fun onActivitySaveInstanceState(outState: Bundle, componentName: ComponentName) {
     outState.putLong(KEY_TIME_OF_SAVE_EPOCH_MILLIS, epochClock())
     outState.putInt(KEY_PID_AT_SAVE, currentPid)
-    outState.putString(KEY_ACTIVITY_NAME, activityName)
+    outState.putParcelable(KEY_COMPONENT_NAME, componentName)
     graveyard?.let {
       outState.putParcelableArrayList(KEY_GRAVEYARD, it.gravestones.toArrayList())
     }
@@ -75,11 +76,11 @@ class Unearthed internal constructor(
         val timeOfSaveEpochMillis =
           savedInstanceState.getLong(KEY_TIME_OF_SAVE_EPOCH_MILLIS)
 
-        val activityName = savedInstanceState.getString(KEY_ACTIVITY_NAME, "")
+        val componentName = savedInstanceState.getParcelable(KEY_COMPONENT_NAME) as? ComponentName
 
         val gravestone = Gravestone(
           pid = pid,
-          activityName = activityName,
+          componentName = componentName,
           restoredAtEpochMillis = now,
           backgroundedEpochMillis = timeOfSaveEpochMillis,
           millisToRestore = now - timeOfSaveEpochMillis


### PR DESCRIPTION
## What
I have scenario which I need to track the screen which happened the process death. So, I would like unearthed provides me the name of this Activity (screen)

## How
Make Gravestone supports `activityName`. We can get the `Activity` from `registerActivityLifecycleCallbacks` and we need to save the activity name in the bundle using this method: `onActivitySaveInstanceState`.

As I used default parameter, I won't break the tests.