### PR TITLE
Implement androidx.startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Changes
 
+## 0.3.0
+
+_(upcoming)_
+
+- BREAKING: Unearthed will initialize itself again via
+  [AndroidX App Startup](https://developer.android.com/topic/libraries/app-startup).
+  Call `Unearthed.initManuallyWithDisabledAndroidXStartup(app)` if you disable AndroidX
+  App Startup.
+
 ## 0.2.0
 
 _(2021-04-10)_
 
-- BREAKING: Unearthed won't initialize itself via a dummy ContentProvider
-  anymore, instead Unearthed.init(app) now has to be called explicitly
+- BREAKING: Unearthed won't initialize itself via a dummy `ContentProvider`
+  anymore, instead `Unearthed.init(app)` now has to be called explicitly
 
 ## 0.1.2
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,7 @@ analytics?
 
 ## Usage
 
-First, initialize Unearthed from your `Application` class' `onCreate` method:
-
-```kotlin
-class MyApp : Application() {
-  override fun onCreate() {
-    super.onCreate()
-
-    Unearthed.init(this)
-  }
-}
-```
+Unearthed will initialize itself via [AndroidX App Startup][androidx-startup].
 
 Wherever convenient, add a listener to `Unearthed` and get notified of
 restoration after process death.
@@ -36,6 +26,12 @@ Unearthed.onProcessRestored { graveyard ->
   trackProcessDeathToAnalytics()
 }
 ```
+
+### Disabling AndroidX App Startup
+
+It's possible to [disable AndroidX App Startup][androidx-startup]. When doing that,
+make sure to call `Unearthed.initManuallyWithDisabledAndroidXStartup(app)` in your
+`Application.onCreate`.
 
 ## Download
 
@@ -64,4 +60,4 @@ at `de.hannesstruss.unearthed:unearthed:0.2.0`.
     See the License for the specific language governing permissions and
     limitations under the License.
 
-[twitter-debate]: https://twitter.com/hannesstruss/status/1107331345762734082
+[androidx-startup]: https://developer.android.com/topic/libraries/app-startup

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -42,6 +42,7 @@ android {
 
 dependencies {
     implementation "androidx.annotation:annotation:1.2.0"
+    implementation "androidx.startup:startup-runtime:1.0.0"
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.3.0'

--- a/library/src/androidTest/java/de/hannesstruss/unearthed/UnearthedTest.kt
+++ b/library/src/androidTest/java/de/hannesstruss/unearthed/UnearthedTest.kt
@@ -1,9 +1,12 @@
 package de.hannesstruss.unearthed
 
+import android.app.Application
 import android.content.ComponentName
 import android.os.Bundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -110,5 +113,18 @@ class UnearthedTest {
     unearthed2.onProcessRestored { graveyardOpt = it }
 
     assertThat(graveyardOpt).isNotNull()
+  }
+
+  @Test
+  fun wontInitializeManuallyTwice() {
+    try {
+      val app =
+        InstrumentationRegistry.getInstrumentation().context.applicationContext as Application
+      Unearthed.initManuallyWithDisabledAndroidXStartup(app)
+      Unearthed.initManuallyWithDisabledAndroidXStartup(app)
+      fail()
+    } catch (e: IllegalStateException) {
+      assertThat(e.message).contains("https://developer.android.com")
+    }
   }
 }

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,3 +1,16 @@
-<manifest package="de.hannesstruss.unearthed">
-    <application/>
+<manifest package="de.hannesstruss.unearthed"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <application>
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+
+            <meta-data
+                android:name="de.hannesstruss.unearthed.UnearthedInitializer"
+                android:value="androidx.startup" />
+        </provider>
+    </application>
 </manifest>

--- a/library/src/main/java/de/hannesstruss/unearthed/Unearthed.kt
+++ b/library/src/main/java/de/hannesstruss/unearthed/Unearthed.kt
@@ -24,14 +24,17 @@ class Unearthed internal constructor(
     private var instance: Unearthed? = null
 
     /**
-     * Initialize Unearthed. Call this from [Application.onCreate].
+     * Initializes Unearthed. Will be called automatically by
+     * [AndroidX App Startup](https://developer.android.com/topic/libraries/app-startup)
+     * unless you choose to disable that. In that case, call this from or before
+     * [Application.onCreate].
      *
      * If you're app runs multiple processes, e.g. when using a library such as LeakCanary
      * or ProcessPhoenix, make sure to read the library docs to only call this method from
      * your main app process.
      */
     @MainThread
-    fun init(app: Application) {
+    internal fun init(app: Application) {
       check(instance == null) { "Unearthed was already initialized" }
 
       instance = Unearthed(currentPid = Process.myPid())
@@ -57,6 +60,19 @@ class Unearthed internal constructor(
         """.trimIndent()
       }
       unearthed.onProcessRestored(callback)
+    }
+
+    @MainThread
+    fun initManuallyWithDisabledAndroidXStartup(app: Application) {
+      check(instance == null) {
+        """Unearthed is already initialized. Either you have called this method twice, or
+          |Unearthed was already initialized via AndroidX App Startup:
+          |
+          |https://developer.android.com/topic/libraries/app-startup
+        """.trimMargin()
+      }
+
+      init(app)
     }
   }
 

--- a/library/src/main/java/de/hannesstruss/unearthed/Unearthed.kt
+++ b/library/src/main/java/de/hannesstruss/unearthed/Unearthed.kt
@@ -31,11 +31,10 @@ class Unearthed internal constructor(
      * your main app process.
      */
     @MainThread
-    fun init(app: Application): Unearthed {
+    fun init(app: Application) {
       check(instance == null) { "Unearthed was already initialized" }
 
-      val newInstance = Unearthed(currentPid = Process.myPid())
-      instance = newInstance
+      instance = Unearthed(currentPid = Process.myPid())
 
       app.registerActivityLifecycleCallbacks(object : EmptyActivityLifecycleCallbacks() {
         override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
@@ -48,8 +47,6 @@ class Unearthed internal constructor(
           unearthed.onActivityCreated(savedInstanceState)
         }
       })
-
-      return newInstance
     }
 
     fun onProcessRestored(callback: (Graveyard) -> Unit) {

--- a/library/src/main/java/de/hannesstruss/unearthed/Unearthed.kt
+++ b/library/src/main/java/de/hannesstruss/unearthed/Unearthed.kt
@@ -31,10 +31,12 @@ class Unearthed internal constructor(
      * your main app process.
      */
     @MainThread
-    fun init(app: Application) {
+    fun init(app: Application): Unearthed {
       check(instance == null) { "Unearthed was already initialized" }
 
-      instance = Unearthed(currentPid = Process.myPid())
+      val newInstance = Unearthed(currentPid = Process.myPid())
+      instance = newInstance
+
       app.registerActivityLifecycleCallbacks(object : EmptyActivityLifecycleCallbacks() {
         override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
           val unearthed = checkNotNull(instance)
@@ -46,6 +48,8 @@ class Unearthed internal constructor(
           unearthed.onActivityCreated(savedInstanceState)
         }
       })
+
+      return newInstance
     }
 
     fun onProcessRestored(callback: (Graveyard) -> Unit) {

--- a/library/src/main/java/de/hannesstruss/unearthed/UnearthedInitializer.kt
+++ b/library/src/main/java/de/hannesstruss/unearthed/UnearthedInitializer.kt
@@ -4,9 +4,9 @@ import android.app.Application
 import android.content.Context
 import androidx.startup.Initializer
 
-class UnearthedInitializer : Initializer<Unearthed> {
-  override fun create(context: Context): Unearthed {
-    return Unearthed.init(context.applicationContext as Application)
+class UnearthedInitializer : Initializer<Unit> {
+  override fun create(context: Context) {
+    Unearthed.init(context.applicationContext as Application)
   }
 
   override fun dependencies(): List<Class<out Initializer<*>>> {

--- a/library/src/main/java/de/hannesstruss/unearthed/UnearthedInitializer.kt
+++ b/library/src/main/java/de/hannesstruss/unearthed/UnearthedInitializer.kt
@@ -1,0 +1,15 @@
+package de.hannesstruss.unearthed
+
+import android.app.Application
+import android.content.Context
+import androidx.startup.Initializer
+
+class UnearthedInitializer : Initializer<Unearthed> {
+  override fun create(context: Context): Unearthed {
+    return Unearthed.init(context.applicationContext as Application)
+  }
+
+  override fun dependencies(): List<Class<out Initializer<*>>> {
+    return emptyList()
+  }
+}

--- a/library/src/main/java/de/hannesstruss/unearthed/UnearthedInitializer.kt
+++ b/library/src/main/java/de/hannesstruss/unearthed/UnearthedInitializer.kt
@@ -4,7 +4,8 @@ import android.app.Application
 import android.content.Context
 import androidx.startup.Initializer
 
-class UnearthedInitializer : Initializer<Unit> {
+@Suppress("unused") // Will be instantiated by AndroidX App Startup.
+internal class UnearthedInitializer : Initializer<Unit> {
   override fun create(context: Context) {
     Unearthed.init(context.applicationContext as Application)
   }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -27,5 +27,4 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0-rc01'
     implementation 'androidx.core:core-ktx:1.6.0-alpha01'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation "androidx.startup:startup-runtime:1.0.0"
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -27,4 +27,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0-rc01'
     implementation 'androidx.core:core-ktx:1.6.0-alpha01'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation "androidx.startup:startup-runtime:1.0.0"
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -19,6 +19,17 @@
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity>
+
+    <provider
+        android:name="androidx.startup.InitializationProvider"
+        android:authorities="${applicationId}.androidx-startup"
+        android:exported="false"
+        tools:node="merge">
+
+      <meta-data
+          android:name="de.hannesstruss.unearthed.UnearthedInitializer"
+          android:value="androidx.startup" />
+    </provider>
   </application>
 
 </manifest>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -20,16 +20,7 @@
       </intent-filter>
     </activity>
 
-    <provider
-        android:name="androidx.startup.InitializationProvider"
-        android:authorities="${applicationId}.androidx-startup"
-        android:exported="false"
-        tools:node="merge">
 
-      <meta-data
-          android:name="de.hannesstruss.unearthed.UnearthedInitializer"
-          android:value="androidx.startup" />
-    </provider>
   </application>
 
 </manifest>

--- a/sample/src/main/java/de/hannesstruss/unearthed/sample/SampleApp.kt
+++ b/sample/src/main/java/de/hannesstruss/unearthed/sample/SampleApp.kt
@@ -8,6 +8,6 @@ class SampleApp : Application() {
   override fun onCreate() {
     super.onCreate()
 
-    Unearthed.init(this)
+//    Unearthed.init(this)
   }
 }


### PR DESCRIPTION
Implements [AndroidX App Startup](https://developer.android.com/topic/libraries/app-startup).

- [x] Docs/Changelog
- [x] Fix tests
- [x] Was it meant to be used like this? @tfcporciuncula
- [x] Is there a way to not be a breaking change _again_ for people who're on 0.2.0 already?